### PR TITLE
FIX: Remove extra quote from command

### DIFF
--- a/course/04.md
+++ b/course/04.md
@@ -359,7 +359,7 @@ Remember that the target does not have InSpec installed on it. Your shell sessio
 Run the `package` resource a second time, this time on the target container.
 
 ```ruby
-package('nginx').installed?'
+package('nginx').installed?
 ```
 
 As you can see, how the InSpec `package` resources returns `true`.


### PR DESCRIPTION
The extra quote command at the end of the command would expect a closing quote and thus resulting an unexpected output.

Signed-off-by: Sonu Saha <sonu.saha@progress.com>